### PR TITLE
Revert "Implement pagination to fetch all blog posts"

### DIFF
--- a/api/getrss.js
+++ b/api/getrss.js
@@ -1,64 +1,27 @@
 const { fetch } = require("undici");
-const { parseStringPromise, Builder } = require("xml2js");
 
 module.exports = async (req, res) => {
   try {
     let { url } = req.body;
-    let fullUrl = url + "/feeds/posts/default";
-    let startIndex = 1;
-    const maxResults = 500;
-    let allEntries = [];
-    let firstFeedData;
+    url += "/feeds/posts/default";
 
-    while (true) {
-      const paginatedUrl = `${fullUrl}?start-index=${startIndex}&max-results=${maxResults}`;
-      const response = await fetch(paginatedUrl, { redirect: "follow" });
+    const response = await fetch(url, { redirect: "follow" });
+    console.log(
+      "Response status:",
+      response.status,
+      "Response OK:",
+      response.ok
+    );
 
-      if (!response.ok) {
-        console.error("Failed to fetch RSS feed:", response.statusText);
-        return res
-          .status(response.status)
-          .json({ error: "Failed to fetch RSS feed" });
-      }
-
-      const data = await response.text();
-      const parsedData = await parseStringPromise(data, {
-        explicitArray: false,
-      });
-
-      if (!firstFeedData) {
-        firstFeedData = { ...parsedData };
-        delete firstFeedData.feed.entry; // Remove entries to be replaced with the full list
-      }
-
-      const entries = parsedData.feed.entry;
-      if (entries) {
-        const postEntries = (Array.isArray(entries) ? entries : [entries]).filter(
-          (entry) =>
-            entry.category &&
-            entry.category.$.term.endsWith("#post")
-        );
-        allEntries = allEntries.concat(postEntries);
-
-        if (postEntries.length < maxResults) {
-          break; // Last page
-        }
-      } else {
-        break; // No entries found
-      }
-
-      startIndex += maxResults;
+    if (!response.ok) {
+      console.error("Failed to fetch RSS feed:", response.statusText);
+      return res
+        .status(response.status)
+        .json({ error: "Failed to fetch RSS feed" });
     }
 
-    if (firstFeedData) {
-      firstFeedData.feed.entry = allEntries;
-      const builder = new Builder();
-      const xml = builder.buildObject(firstFeedData);
-      res.status(200).send(xml);
-    } else {
-      // Handle case where the feed was empty from the start
-      res.status(200).send('<?xml version="1.0" encoding="UTF-8"?><feed/>');
-    }
+    const data = await response.text();
+    res.status(200).send(data);
   } catch (error) {
     console.error("Fetch Error:", error.message);
     res.status(500).json({ error: "Internal Server Error" });

--- a/api/rsstoxml.js
+++ b/api/rsstoxml.js
@@ -139,7 +139,7 @@ async function extractRssInfo(atomData) {
       return rv;
     }
 
-    const atomEntries = itemsArray.map((item) => {
+    const atomEntries = itemsArray.slice(0, 5).map((item) => {
       const id = item.id || "";
       const postId = id.split(".post-")[1];
       let content =


### PR DESCRIPTION
Reverts Soumyabrataop/Scrapapp#1

## Summary by Sourcery

Revert the pagination logic for RSS feeds and simplify feed fetching and XML conversion.

Enhancements:
- Simplify the getrss endpoint to perform a single HTTP fetch and return raw RSS XML without parsing or pagination
- Add console.log statements to report the HTTP response status and success flag
- Limit RSStoXML conversion to the first five entries by slicing the items array